### PR TITLE
Update .eleventy.js

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -62,7 +62,7 @@ module.exports = function (config, options = defaultOptions) {
     }
 
     const svgEntry = cache[faviconFile].svg
-      ? '<link rel="icon" type="image/svg+xml" href="/favicon.svg"></link>'
+      ? '<link rel="icon" type="image/svg+xml" href="/favicon.svg">'
       : "";
 
     return `


### PR DESCRIPTION
Remove closing link tag. Used with eleventy vite plugin, the plugin throws an error because of the closing tag.

`Encountered a Vite build error, restoring original Eleventy output to _site Error: Unable to parse HTML; parse5 error code end-tag-without-matching-open-element`

Since the closing tag is useless, I think it can be safely removed.